### PR TITLE
hotfix method getOders of SortUtil

### DIFF
--- a/src/main/java/com/idforideas/pizzeria/utils/SortUtil.java
+++ b/src/main/java/com/idforideas/pizzeria/utils/SortUtil.java
@@ -1,6 +1,11 @@
 package com.idforideas.pizzeria.utils;
 
 import static java.util.Arrays.stream;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.data.domain.Sort.Order.asc;
+import static org.springframework.data.domain.Sort.Order.desc;
+import static org.springframework.data.domain.Sort.Order.by;
 
 import java.util.List;
 
@@ -8,19 +13,16 @@ import org.springframework.data.domain.Sort.Order;
 
 public abstract class SortUtil {
 
-    // FIXME Probar que la logica de negocio funciona
-    // Actualmente ve el segundo indice como propiedad
-    public static List<Order> getOrders(String[] sort) {
+   public static List<Order> getOrders(String[] sort) {
         return stream(sort)
             .map(s -> s.split(","))
-            .map(o ->  {
-                if(o.length == 1) {
-                    return Order.by(o[0]);
+            .map(a ->  {
+                if(stream(a).filter(str -> str.equalsIgnoreCase(ASC.name()) || str.equalsIgnoreCase(DESC.name())).findFirst().isPresent()) {
+                    return a[1].equalsIgnoreCase(ASC.name()) ? asc(a[0]) : desc(a[0]);
                 }
-                if (o[1].contains("desc") || o[1].contains("asd")) {
-                    return o[1].contains("asd") ? Order.asc(o[0]) : Order.desc(o[0]);
+                else {
+                    return by(a[0]);
                 }
-                return null;
             }).toList();
     }
 }


### PR DESCRIPTION
**hotfix** de la clase de utilidad **SortUtil**. Existía un bug que no permitía ordenar los request en resource paginables.